### PR TITLE
Initial wit extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Demonstrates advanced extension concepts like AMD loading, using UI controls, hi
 
 ![image](ui/images/menu-dropdown2.png)
 
-Explore different UI controls, including menus, toolbars, custom controls, and more.
+Explore different UI controls, including menus, toolbars, custom controls, work item form extensions, and more.
 
 ### Public events (for Team Calendar)
 

--- a/ui/menu-workItemToolbarButton.html
+++ b/ui/menu-workItemToolbarButton.html
@@ -1,0 +1,78 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <title>Work item menu contribution sample</title>
+</head>
+
+<body>
+    <script src="sdk/scripts/VSS.SDK.js"></script>
+    <script>
+
+        VSS.init({ usePlatformScripts: true });
+
+        // Get the ActiveWorkItemService.  This service allows you to get/set fields/links on the 'active' work item (the work item
+        // that currently is displayed in the UI).
+        function getActiveWorkItemService()
+        {
+            var deferred = $.Deferred();
+            
+            VSS.require(["TFS/WorkItemTracking/Services"], function(_WorkItemServices) {
+                _WorkItemServices.ActiveWorkItemService.getService().then(function (service) {
+                    deferred.resolve(service)
+                },
+                function() {
+                    deferred.reject();
+                });
+            });
+
+            return deferred.promise();           
+        }
+
+
+        // Register a listener for the menu item contribution
+        VSS.register("MenuItemListener", function (context) {
+            return {
+                setFields: function(properties, title) {
+                    
+                    // Get the active work item service
+                    getActiveWorkItemService().then(function (service) {
+                        // Set a field value
+                        service.setFieldValue("System.Title", "Hello from your extension!").then(
+                            function () {
+                                // Success!
+                            }, 
+                            function(error) {
+                                // Error 
+                                window.alert(error.message); });
+                        },
+                        function(error) {
+                            // Error getting the service 
+                            window.alert(error.message); 
+                        });
+                },
+                
+                // Called when the menu item is clicked.
+                execute: function(actionContext) {
+                    this.setFields(actionContext);
+                },
+                
+                // event handlers, called when the active work item is loaded/unloaded/modified/saved
+                onFieldChanged: function (args) {
+                },
+                onLoaded: function (args) {
+                },
+                onUnloaded: function (args) {
+                },
+                onSaved: function (args) {
+                },
+                onReset: function (args) {
+                },
+                onRefreshed: function (args) {
+                }
+            };
+        });
+    </script>
+</body>
+</html>

--- a/ui/vss-extension.json
+++ b/ui/vss-extension.json
@@ -139,6 +139,36 @@
                 "order": 110,
                 "uri": "workItemService.html"
             }
+        },
+        {
+            "id": "sample-work-item-menu",
+            "type": "ms.vss-web.action",
+            "description": "Shows the target properties for menu actions for work items",
+            "targets": [
+                "ms.vss-work-web.work-item-context-menu",
+                "ms.vss-work-web.active-work-item-notifications"
+            ],
+            "properties": {
+                "text": "Try me!",
+                "title": "ms.vss-work-web.work-item-context-menu",
+                "toolbarText": "Try me!",
+                "icon": "images/show-properties.png",
+                "uri": "menu-workItemToolbarButton.html",
+                "registeredObjectId": "MenuItemListener"
+            }
+        },
+        {
+            "id": "work-item-form-tab",
+            "type": "ms.vss-work-web.work-item-form-page",
+            "description": "Shows a new tab page on all work item types",
+            "targets": [
+                "ms.vss-work-web.work-item-form-pages"
+            ],
+            "properties": {
+                "name": "My Page",
+                "uri": "workItemTabPage.html",
+                "registeredObjectId": "SamplePageWorkItemListener"
+            }
         }
     ]
 }

--- a/ui/workItemTabPage.html
+++ b/ui/workItemTabPage.html
@@ -1,0 +1,98 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <title>Work item extension page sample</title>
+</head>
+
+<body style="overflow:auto;">
+    <script src="sdk/scripts/VSS.SDK.js"></script>
+
+    <script>
+
+        VSS.init({ usePlatformScripts: true });
+
+        // Get the ActiveWorkItemService.  This service allows you to get/set fields/links on the 'active' work item (the work item
+        // that currently is displayed in the UI).
+        function getActiveWorkItemService()
+        {
+            var deferred = $.Deferred();
+            
+            VSS.require(["TFS/WorkItemTracking/Services"], function(_WorkItemServices) {
+                _WorkItemServices.ActiveWorkItemService.getService().then(function (service) {
+                    deferred.resolve(service)
+                },
+                function() {
+                    deferred.reject();
+                });
+            });
+
+            return deferred.promise();           
+        }
+
+        // Register a listener for the work item page contribution
+        VSS.register("SamplePageWorkItemListener", function () {
+            return {
+                // Called when the active work item is modified
+                onFieldChanged: function(args) {
+                    $(".events").append($("<div/>").text("onFieldChanged - " + JSON.stringify(args)));
+                },
+                
+                // Called when a new work item is being loaded in the UI
+                onLoaded: function (args) {
+        
+                    getActiveWorkItemService().then(function(service) {            
+                        // Get the current values for a few of the common fields
+                        service.getFieldValues(["System.Id", "System.Title", "System.State", "System.CreatedDate"]).then(
+                            function (value) {
+                                $(".events").append($("<div/>").text("onLoaded - " + JSON.stringify(value)));
+                            },
+                            function(error) { 
+                                window.alert(error.message); 
+                            });
+                    });
+                },
+                
+                // Called when the active work item is being unloaded in the UI
+                onUnloaded: function (args) {
+                    $(".events").empty();
+                    $(".events").append($("<div/>").text("onUnloaded - " + JSON.stringify(args)));
+                },
+                
+                // Called after the work item has been saved
+                onSaved: function (args) {
+                    $(".events").append($("<div/>").text("onSaved - " + JSON.stringify(args)));
+                },
+                
+                // Called when the work item is reset to its unmodified state (undo)
+                onReset: function (args) {
+                    $(".events").append($("<div/>").text("onReset - " + JSON.stringify(args)));
+                },
+                
+                // Called when the work item has been refreshed from the server
+                onRefreshed: function (args) {
+                    $(".events").append($("<div/>").text("onRefreshed - " + JSON.stringify(args)));
+                }
+            }
+        });
+
+        VSS.ready(function () {
+            // register a handler for the 'Click me!' button.        
+    
+             $("#clickme").click(function() {
+                 getActiveWorkItemService().then(function(service) {
+                     service.setFieldValue("System.Title", "Title set from extension!")
+                 });
+             });
+         });
+
+    </script>
+
+    <p> Hello, your work item tab page contribution is now active! </p>
+    <button type="button" id="clickme">Click me!</button>
+    <div class='events'> </div>
+
+</body>
+
+</html>


### PR DESCRIPTION
Added the initial implementation of samples for WIT.  There are two defined, one adding a toolbar button to the WIT form, the other adding a new tab page and control to the wit form.